### PR TITLE
Eclipse depth is planetary and instrumental parameter

### DIFF
--- a/juliet/fit.py
+++ b/juliet/fit.py
@@ -78,7 +78,7 @@ G = 6.67408e-11 # Gravitational constant, mks
 log2pi = np.log(2.*np.pi) # ln(2*pi)
 
 # Import all the utils functions:
-from .utils import *
+from utils import *
 
 __all__ = ['load','fit','gaussian_process','model']
 
@@ -585,7 +585,8 @@ class load(object):
                     dictionary[inames[i]]['TranEclFit'] = True
                     dictionary[inames[i]]['TransitFit'] = False
                     dictionary[inames[i]]['EclipseFit'] = False
-                    print('\t Joint Transit and Eclipse fit detected for instrument ',inames[i])
+                    if self.verbose:
+                        print('\t Joint Transit and Eclipse fit detected for instrument ',inames[i])
             for pi in numbering_planets:
                 for i in range (ninstruments):
                     if dictionary[inames[i]]['TTVs'][pi]['status']:
@@ -2563,16 +2564,19 @@ class model(object):
                 else:
                     coeff1 = parameter_values['q1_'+self.ld_iname[instrument]]
 
+                ### For instrument dependent eclipse depth:
+                ### We only want to make eclipse depth instrument depended, not the time correction factor
+                for i in self.numbering:
+                    if self.dictionary[instrument]['EclipseFit'] or self.dictionary[instrument]['TranEclFit']:
+                        fp = parameter_values['fp_p' + str(i) + '_' + self.fp_iname[instrument]]
+                        ac = parameter_values['ac_p' + str(i)]
+                ###
+
                 # First (1) check if TTV mode is activated. If it is not, simply save the sampled planet periods and time-of transit centers for check
                 # in the next round of iteration (see below). If it is, depending on the parametrization, either shift the time-indexes accordingly (see below
                 # comments for details).
                 cP, ct0 = {}, {}
                 for i in self.numbering:
-                    ###
-                    if self.dictionary[instrument]['EclipseFit'] or self.dictionary[instrument]['TranEclFit']:
-                        fp = parameter_values['fp_p' + str(i)]
-                        ac = parameter_values['ac_p' + str(i)]
-                    ###
                     # Check if we will be fitting for TTVs. If not, all goes as usual. If we are, check which parametrization (dt or T):
                     if not self.dictionary[instrument]['TTVs'][i]['status']:
                         t0, P = parameter_values['t0_p'+str(i)], parameter_values['P_p'+str(i)]
@@ -2877,9 +2881,10 @@ class model(object):
                 self.model['global'] = np.zeros(len(self.t))
                 self.model['global_variances'] = np.zeros(len(self.t))
                 self.model['deterministic'] = np.zeros(len(self.t))
-            # If limb-darkening or dilution factors will be shared by different instruments, set the correct variable name for each:
+            # If limb-darkening, dilution factors or eclipse depth will be shared by different instruments, set the correct variable name for each:
             self.ld_iname = {}
             self.mdilution_iname = {}
+            self.fp_iname = {}
             self.ndatapoints_all_instruments = 0.
             # Variable that turns to false only if there are no TTVs. Otherwise, always positive:
             self.Tflag = False
@@ -2971,6 +2976,15 @@ class model(object):
                             else:
                                 if instrument in vec:
                                     self.mdilution_iname[instrument] = vec[1]
+                        if pname[0:2] == 'fp':
+                            # Note that eclipse depth is planetary and instrumental parameter
+                            vec = pname.split('_')
+                            if len(vec) > 3:
+                                if instrument in vec:
+                                    self.fp_iname[instrument] = '_'.join(vec[2:])
+                            else:
+                                if instrument in vec:
+                                    self.fp_iname[instrument] = vec[2]
                 else:
                     # Now proceed with instrument namings:
                     for pname in self.priors.keys():

--- a/juliet/fit.py
+++ b/juliet/fit.py
@@ -78,7 +78,7 @@ G = 6.67408e-11 # Gravitational constant, mks
 log2pi = np.log(2.*np.pi) # ln(2*pi)
 
 # Import all the utils functions:
-from utils import *
+from .utils import *
 
 __all__ = ['load','fit','gaussian_process','model']
 


### PR DESCRIPTION
This pull request makes the eclipse depth both planetary and instrumental parameters. That means users now have to use `fp_p1_instrument` while providing priors on eclipse depth. Users can combine `fp` over multiple instruments (just like limb darkening coefficients) by `fp_p1_instrument1_instrument2`.